### PR TITLE
Identify lab session correctly

### DIFF
--- a/src/stores/attendance.ts
+++ b/src/stores/attendance.ts
@@ -243,7 +243,7 @@ export const useAttendanceStore = defineStore("attendance", {
           useSyncQueue().enqueueAttendance({
             id: crypto.randomUUID(),
             type: "attendance.lab",
-            dedupeKey: labDedupeKey(date, group),
+            dedupeKey: labDedupeKey(praktikumDay, group),
             payload,
             createdAt: new Date().toISOString(),
             status: "pending",

--- a/src/stores/syncQueue.ts
+++ b/src/stores/syncQueue.ts
@@ -18,8 +18,8 @@ export type AttendanceQueueItem = {
   status: "pending" | "syncing" | "failed";
 };
 
-export function labDedupeKey(date: string, group: string): string {
-  return `lab:${date}:${group}`;
+export function labDedupeKey(praktikumDay: number, group: string): string {
+  return `lab:${group}:${praktikumDay}`;
 }
 
 export function seminarDedupeKey(date: string): string {


### PR DESCRIPTION
This is a fix for the following problem: The key identifying a lab session to queue and later send to server was wrong: it was group + date, which may lead to overwrite when a second lab session for the date is added to queue.